### PR TITLE
Replace use of deprecated `SecurityContext` with `TokenStorage`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+## 0.2.0
+
+* Replaces use of `SecurityContext` with `TokenStorage` as it is deprecated in Symfony 2.6 and will be removed in Symfony 3.0

--- a/DependencyInjection/Compiler/SecurityFeaturePass.php
+++ b/DependencyInjection/Compiler/SecurityFeaturePass.php
@@ -19,7 +19,7 @@ class SecurityFeaturePass implements CompilerPassInterface
     {
         $plugins = $container->getParameter('hautelook_sentry.plugins');
 
-        if ($container->has('security.context')
+        if ($container->has('security.token')
             && isset($plugins['user'])
             && $plugins['user']
         ) {

--- a/Resources/config/sentry.xml
+++ b/Resources/config/sentry.xml
@@ -59,7 +59,7 @@
         </service>
 
         <service id="hautelook_sentry.factory.user" class="%hautelook_sentry.factory.user.class%" public="false">
-            <argument type="service" id="security.context"/>
+            <argument type="service" id="security.token"/>
         </service>
 
         <service id="hautelook_sentry.plugin.cli" class="%hautelook_sentry.plugin.cli.class%" public="false">

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,8 @@
+Upgrading
+===============
+
+Upgrade from 0.1.x to 0.2.x
+-----------------------
+
+0.2.x replaces the use of Symfony `SecurityContext` with `TokenStorage` which was added in Symfony 2.6. 
+To use 0.2 you will need to be running Symfony 2.6 or greater.

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
     ],
     "require": {
         "php": ">=5.3",
-        "symfony/framework-bundle": "~2.3",
-        "symfony/console": "~2.3",
+        "symfony/framework-bundle": ">=2.6",
+        "symfony/console": ">=2.6",
         "hautelook/sentry-client": "~0.1"
     },
     "require-dev": {


### PR DESCRIPTION
The Symfony `SecurityContext` was deprecated in Symfony 2.6 and will be removed in Symfony 3.0. This PR replaces it's use with the new TokenStorage. 

As the update is a breaking change to anyone using this bundle with a version of Symfony less than 2.6 I have tagged this as 0.2.0 and added CHANGELOG.md and UPDATE.md.