### PR TITLE
Use security.token_storage when available

### DIFF
--- a/Resources/config/sentry.xml
+++ b/Resources/config/sentry.xml
@@ -59,7 +59,7 @@
         </service>
 
         <service id="hautelook_sentry.factory.user" class="%hautelook_sentry.factory.user.class%" public="false">
-            <argument type="service" id="security.context"/>
+            <argument type="service" id="security.token_storage"/>
         </service>
 
         <service id="hautelook_sentry.plugin.cli" class="%hautelook_sentry.plugin.cli.class%" public="false">


### PR DESCRIPTION
Fixes #5 

Deployed to production, and see what happened:
<img width="1072" alt="screen shot 2015-10-12 at 16 05 54" src="https://cloud.githubusercontent.com/assets/104180/10429761/36d609aa-70fb-11e5-9c3f-6418d8c01d28.png">
