### PR TITLE
Update sentry-client version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": ">=5.3",
         "symfony/framework-bundle": "~2.3|~3.0",
         "symfony/console": "~2.3|~3.0",
-        "hautelook/sentry-client": "~0.1"
+        "hautelook/sentry-client": "~1.0"
     },
     "require-dev": {
         "hautelook/frankenstein": "0.1.*",


### PR DESCRIPTION
This bundle was updated to use token storage instead of context, but the
underlying sentry-client dependency was never updated to support this
change.

Fixes #10 