### PR TITLE
Inject RequestStack when available

### DIFF
--- a/Resources/config/sentry.xml
+++ b/Resources/config/sentry.xml
@@ -52,6 +52,9 @@
             <call method="setRequest">
                 <argument type="service" id="request" on-invalid="null" strict="false" />
             </call>
+            <call method="setRequestStack">
+                <argument type="service" id="request_stack" on-invalid="null" strict="false" />
+            </call>
         </service>
 
         <service id="hautelook_sentry.plugin.user" class="%hautelook_sentry.plugin.user.class%" public="false">


### PR DESCRIPTION
Added to support passing the request along in newer versions of Symfony. Complete fix for hautelook/SentryBundle#12, along with hautelook/sentry-client#19.